### PR TITLE
Babel doesn't like bibliographic codes for languages

### DIFF
--- a/cms/tests/test_views.py
+++ b/cms/tests/test_views.py
@@ -52,7 +52,8 @@ class TestViews(UnicoreTestCase):
 
         languages = ("[('eng_GB', 'English'), ('swa_KE', 'Swahili'),"
                      "('spa_ES', 'Spanish'), ('fra_FR', 'French'),"
-                     "('hin_IN', 'Hindi'), ('ind_ID', 'Bahasa')]")
+                     "('hin_IN', 'Hindi'), ('ind_ID', 'Bahasa'),"
+                     "('per_IR', 'Persian')]")
         featured_langs = "[('spa_ES', 'Spanish'), ('eng_GB', 'English')]"
 
         settings = {

--- a/cms/tests/test_views.py
+++ b/cms/tests/test_views.py
@@ -51,7 +51,7 @@ class TestViews(UnicoreTestCase):
         })
 
         languages = ("[('eng_GB', 'English'), ('swa_KE', 'Swahili'),"
-                     "('spa_ES', 'Spanish'), ('fra_FR', 'French'),"
+                     "('spa_ES', 'Spanish'), ('fre_FR', 'French'),"
                      "('hin_IN', 'Hindi'), ('ind_ID', 'Bahasa'),"
                      "('per_IR', 'Persian')]")
         featured_langs = "[('spa_ES', 'Spanish'), ('eng_GB', 'English')]"
@@ -115,8 +115,8 @@ class TestViews(UnicoreTestCase):
     def test_get_available_languages(self):
         languages = self.views.get_available_languages
         self.assertEqual(languages[1][0], 'eng_GB')
-        self.assertEqual(languages[5][0], 'swa_KE')
-        self.assertEqual(languages[5][1], 'Kiswahili')
+        self.assertEqual(languages[6][0], 'swa_KE')
+        self.assertEqual(languages[6][1], 'Kiswahili')
 
     def test_get_featured_category_pages(self):
         category1, category2 = self.create_categories(self.workspace)
@@ -487,12 +487,12 @@ class TestViews(UnicoreTestCase):
         self.assertEqual(
             langs, [('eng_GB', 'English'), ('spa_ES', u'espa\xf1ol')])
 
-        request = testing.DummyRequest({'_LOCALE_': 'fra_FR'})
+        request = testing.DummyRequest({'_LOCALE_': 'fre_FR'})
         self.views = CmsViews(request)
         langs = self.views.get_display_languages()
         self.assertEqual(
             langs,
-            [('fra_FR', u'fran\xe7ais'), ('eng_GB', 'English'),
+            [('fre_FR', u'fran\xe7ais'), ('eng_GB', 'English'),
              ('spa_ES', u'espa\xf1ol')])
 
         request = testing.DummyRequest({'_LOCALE_': 'spa_ES'})
@@ -511,4 +511,7 @@ class TestViews(UnicoreTestCase):
             in resp.body.decode('utf-8'))
         self.assertTrue(
             u'<a href="/locale/swa_KE/">Kiswahili</a>'
+            in resp.body.decode('utf-8'))
+        self.assertTrue(
+            u'<a href="/locale/per_IR/">\u0641\u0627\u0631\u0633\u06cc</a>'
             in resp.body.decode('utf-8'))

--- a/cms/views/cms_views.py
+++ b/cms/views/cms_views.py
@@ -1,6 +1,7 @@
 from ast import literal_eval
 
 from babel import Locale
+from pycountry import languages
 
 from beaker.cache import cache_region
 
@@ -42,8 +43,10 @@ class CmsViews(BaseCmsView):
             (code, self.get_display_name(code))
             for code, name in featured_languages]
 
-    def get_display_name(self, language_code):
-        return Locale.parse(language_code).language_name
+    def get_display_name(self, locale):
+        language_code, _, country_code = locale.partition('_')
+        term_code = languages.get(bibliographic=language_code).terminology
+        return Locale.parse(term_code).language_name
 
     def get_display_languages(self):
         to_display = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ python-dateutil
 libthumbor
 unicore.content
 unicore.google
+pycountry==1.10


### PR DESCRIPTION
e.g `fre_FR` doesn't resolve in favour of `fra_FR`

Other codes include `per` in favour for `fas`
Need to run `babel.Locale.parse()` on all our codes