### PR TITLE
don't raise exception if category does not exist

### DIFF
--- a/cms/templates/comments/comment_page.jinja2
+++ b/cms/templates/comments/comment_page.jinja2
@@ -6,11 +6,13 @@
 
 {% block content %}
 <div class="content">
+    {% if primary_category %}
     <div>
         <a href="{{ request.route_url('category_jinja2', category=primary_category.uuid) }}">
         {{ molecules.image_and_heading(view, primary_category) }}
         </a>
     </div>
+    {% endif %}
 
     <h2>{{ page.title }}</h2>
 

--- a/cms/templates/content.pt
+++ b/cms/templates/content.pt
@@ -1,8 +1,8 @@
 <div metal:use-macro="view.global_template">
     <div metal:fill-slot="content">
 
-        <div class="page section_news object-detail ${primary_category.slug}-detail">
-            <div class="h1">
+        <div class="page section_news object-detail ${cat_class}" tal:define="cat_class '%s-detail' % primary_category.slug if primary_category else ''">
+            <div class="h1" tal:condition="primary_category">
                 <img src="/static/img/icon-${primary_category.slug}.jpg"/>
                 <a href="/content/list/${primary_category.uuid}/">${primary_category.title}</a>
                 <div class="clear"></div>

--- a/cms/tests/test_views.py
+++ b/cms/tests/test_views.py
@@ -41,7 +41,7 @@ class TestViews(UnicoreTestCase):
                     'index': 'not_analyzed',
                 },
                 'position': {
-                    'type': 'integer'
+                    'type': 'long'
                 }
             }
         })

--- a/cms/tests/test_views.py
+++ b/cms/tests/test_views.py
@@ -5,6 +5,7 @@ import pytz
 from chameleon import PageTemplate
 from pyramid import testing
 from pyramid_beaker import set_cache_regions_from_settings
+from pyramid.httpexceptions import HTTPNotFound
 
 from cms import locale_negotiator_with_fallbacks
 from cms.tests.base import UnicoreTestCase
@@ -38,6 +39,9 @@ class TestViews(UnicoreTestCase):
                 'language': {
                     'type': 'string',
                     'index': 'not_analyzed',
+                },
+                'position': {
+                    'type': 'integer'
                 }
             }
         })
@@ -231,6 +235,20 @@ class TestViews(UnicoreTestCase):
         self.assertEqual(
             response['description'], '<p><em>emphasised</em></p>')
 
+    def test_views_no_primary_category(self):
+        [page] = self.create_pages(
+            self.workspace,
+            linked_pages=None,
+            count=1, content='', description='',
+            primary_category=None)
+
+        # checks that relevant views don't generate exceptions
+        self.app.get('/')
+        self.app.get('/spice/')
+        self.app.get('/content/detail/%s/' % page.uuid)
+        self.app.get('/spice/content/detail/%s/' % page.uuid)
+        self.app.get('/content/comments/%s/' % page.uuid)
+
     def test_flatpage_markdown_rendering(self):
         [category] = self.create_categories(self.workspace, count=1)
         [page] = self.create_pages(
@@ -289,6 +307,13 @@ class TestViews(UnicoreTestCase):
         self.assertEqual(cat4.uuid, category1.uuid)
 
     def test_get_category(self):
+        request = testing.DummyRequest({'_LOCALE_': 'swa_KE'})
+        views = CmsViews(request)
+
+        for does_not_exist in (None, 'abcd'):
+            self.assertIs(views.get_category(does_not_exist), None)
+
+    def test_category_view(self):
         [category] = self.create_categories(
             self.workspace, count=1, language='swa_KE')
         [page] = self.create_pages(
@@ -302,6 +327,14 @@ class TestViews(UnicoreTestCase):
         self.assertEqual(response['category'].uuid, category.uuid)
         self.assertEqual(
             [p.uuid for p in response['pages']], [page.uuid])
+
+    def test_category_view_does_not_exist(self):
+        request = testing.DummyRequest({'_LOCALE_': 'swa_KE'})
+        views = CmsViews(request)
+
+        for does_not_exist in (None, 'abcd'):
+            request.matchdict['category'] = does_not_exist
+            self.assertRaises(HTTPNotFound, views.category)
 
     def test_pages_ordering(self):
         [category] = self.create_categories(self.workspace, count=1)

--- a/cms/views/cms_views.py
+++ b/cms/views/cms_views.py
@@ -134,8 +134,11 @@ class CmsViews(BaseCmsView):
 
     @cache_region(CACHE_TIME)
     def get_category(self, uuid):
-        [category] = self.workspace.S(Category).filter(uuid=uuid)
-        return category.to_object()
+        try:
+            [category] = self.workspace.S(Category).filter(uuid=uuid)
+            return category.to_object()
+        except ValueError:
+            return None
 
     def get_pages(self, limit=5, order_by=('position', '-modified_at')):
         """
@@ -250,7 +253,7 @@ class CmsViews(BaseCmsView):
         category_id = self.request.matchdict['category']
         category = self.get_category(category_id)
 
-        if category.language != self.locale:
+        if category is None or category.language != self.locale:
             raise HTTPNotFound()
 
         pages = self.get_pages_for_category(category_id, self.locale)


### PR DESCRIPTION
`CmsViews.get_category` raises a `ValueError` if a category with the uuid does not exist. It should rather return None, same as `get_localisation` and `get_page`. Similarly, the category view should return 404 and not error when the category does not exist.